### PR TITLE
CI/CD: disable health check

### DIFF
--- a/.github/workflows/periodic_health_check.yml
+++ b/.github/workflows/periodic_health_check.yml
@@ -1,8 +1,8 @@
 name: Periodic Health Check
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'
+  #schedule:
+  #  - cron: '*/10 * * * *'
 
 jobs:
   periodic_health_check:
@@ -10,7 +10,6 @@ jobs:
     steps:
       - name: Check the deployed service URL 
         uses: jtalk/url-health-check-action@v1.5
-        if: ${{ github.event_name == 'push' }}
         with:
           url: https://moch-pokedex.herokuapp.com
           max-attempts: 3


### PR DESCRIPTION
Disable health check to prevent it from consuming the heroku monthly
free hours.